### PR TITLE
feat: 알림 ON/OFF 기능 구현 및 푸시 발송 조건 수정

### DIFF
--- a/src/main/java/com/iot7/entity/User.java
+++ b/src/main/java/com/iot7/entity/User.java
@@ -37,6 +37,9 @@ public class User {
     @Temporal(TemporalType.TIMESTAMP)
     private Date regDate;
 
+    @Column(name = "NOTIFICATION_YN")
+    private String notificationYn;
+
     // 푸시 토큰
     private String pushToken;
 }

--- a/src/main/java/com/iot7/service/PushTokenService.java
+++ b/src/main/java/com/iot7/service/PushTokenService.java
@@ -1,6 +1,7 @@
 package com.iot7.service;
 
 import com.iot7.entity.Menu;
+import com.iot7.entity.User;
 import com.iot7.repository.MenuRepository;
 import com.iot7.repository.PushTokenRepository;
 import com.iot7.repository.SubscriptionRepository;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,35 +19,41 @@ public class PushTokenService {
 
     private final MenuRepository menuRepository;
     private final SubscriptionRepository subscriptionRepository;
-    private final PushTokenRepository pushTokenRepository;
+    private final UserRepository userRepository; // ✅ 추가
     private final FirebasePushUtil firebasePushUtil;
 
     // ✅ 메뉴 저장 + 구독자에게 푸시 알림 전송
     public void saveMenuAndNotify(Menu menu) {
         System.out.println("🔔 알림 서비스 실행됨: " + menu.getMenuName());
+
         // 1. 메뉴 저장
         menuRepository.save(menu);
 
-
-        // 2. 메뉴에 연결된 브랜드 ID
+        // 2. 브랜드 ID 가져오기
         Long businessId = menu.getBusinessUser().getBusinessId();
         System.out.println("📦 브랜드 ID: " + businessId);
 
-
-        // 3. 이 브랜드를 구독 중인 사용자 ID 목록 조회
+        // 3. 해당 브랜드를 구독한 사용자 ID 리스트 가져오기
         List<Long> userIds = subscriptionRepository.findUserIdsByBusinessId(businessId);
         System.out.println("👥 구독자 수: " + userIds.size());
 
-        // 4. 각 유저에게 푸시 알림 전송
+        // 4. 각 사용자에게 푸시 발송 (조건: 알림 ON + 푸시 토큰 존재)
         for (Long userId : userIds) {
-            String token = pushTokenRepository.findPushTokenByUserId(userId.toString()); // ✅ String으로 변환
-            System.out.println("➡️ userId: " + userId + ", token: " + token);
-            if (token != null) {
-                firebasePushUtil.sendNotification(
-                        token,
-                        "📢 신메뉴 알림!",
-                        menu.getMenuName() + "가 출시되었어요!"
-                );
+            Optional<User> optionalUser = userRepository.findById(userId.toString());
+
+            if (optionalUser.isPresent()) {
+                User user = optionalUser.get();
+
+                if ("Y".equals(user.getNotificationYn()) && user.getPushToken() != null) {
+                    firebasePushUtil.sendNotification(
+                            user.getPushToken(),
+                            "📢 신메뉴 알림!",
+                            menu.getMenuName() + "가 출시되었어요!"
+                    );
+                    System.out.println("✅ 발송됨: " + user.getUserId());
+                } else {
+                    System.out.println("🚫 알림 OFF 또는 토큰 없음: " + user.getUserId());
+                }
             }
         }
     }


### PR DESCRIPTION
- USER 테이블에 NOTIFICATION_YN 컬럼 추가 및 엔티티 반영
- 알림 수신 여부 확인 후 푸시 발송 조건에 notificationYn == 'Y' 추가
- 알림 ON/OFF 설정 API (PATCH /api/push-token/toggle) 추가
- 프론트에서 알림 OFF 상태일 경우 푸시 토큰 발급 및 전송 생략
- /api/push-token 응답을 token + notificationYn 구조로 변경